### PR TITLE
Fix the struct returned by insert() does not return the correct timestamp

### DIFF
--- a/lib/ratchet_wrench/repo.ex
+++ b/lib/ratchet_wrench/repo.ex
@@ -67,9 +67,11 @@ defmodule RatchetWrench.Repo do
 
 
   def insert(struct) do
-    struct = set_timestamps(struct)
+    now_timestamp = RatchetWrench.DateTime.now()
+
+    struct = set_timestamps(struct, now_timestamp)
     sql = insert_sql(struct)
-    params = params_insert_values_map(struct)
+    params = params_insert_values_map(struct, now_timestamp)
     param_types = param_types(struct.__struct__)
 
     case RatchetWrench.execute_sql(sql, params, param_types) do
@@ -78,8 +80,7 @@ defmodule RatchetWrench.Repo do
     end
   end
 
-  defp set_timestamps(struct) do
-    now_timestamp = RatchetWrench.DateTime.now()
+  defp set_timestamps(struct, now_timestamp) do
     set_uuid_value(struct)
     |> set_inserted_at_value(now_timestamp)
     |> set_updated_at_value(now_timestamp)
@@ -100,9 +101,7 @@ defmodule RatchetWrench.Repo do
     "INSERT INTO #{table_name}(#{column_list_string}) VALUES(#{values_list_string})"
   end
 
-  def params_insert_values_map(struct) do
-    now_timestamp = RatchetWrench.DateTime.now()
-
+  def params_insert_values_map(struct, now_timestamp) do
     set_uuid_value(struct)
     |> set_inserted_at_value(now_timestamp)
     |> set_updated_at_value(now_timestamp)

--- a/test/ratchet_wrench/repo_test.exs
+++ b/test/ratchet_wrench/repo_test.exs
@@ -114,6 +114,8 @@ defmodule RatchetWrench.RepoTest do
     assert result.singer_id == struct.singer_id
     assert result.inserted_at.time_zone == "Asia/Tokyo"
     assert result.updated_at.time_zone == "Asia/Tokyo"
+    assert result.inserted_at == struct.inserted_at
+    assert result.updated_at == struct.updated_at
 
     {:ok, result_set} = RatchetWrench.Repo.delete(Singer, [struct.singer_id])
 
@@ -258,13 +260,16 @@ defmodule RatchetWrench.RepoTest do
 
   test ".params_insert_values_map/1" do
     singer = %Singer{first_name: "test_first_name"}
-    params = RatchetWrench.Repo.params_insert_values_map(singer)
+    now_timestamp = RatchetWrench.DateTime.now()
+    params = RatchetWrench.Repo.params_insert_values_map(singer, now_timestamp)
     assert params.first_name == "test_first_name"
     assert params.last_name == nil
     assert byte_size(params.singer_id ) == 36 # uuidv4
     assert is_binary(params.inserted_at)
     assert is_binary(params.updated_at)
     assert params.inserted_at == params.updated_at
+    assert params.inserted_at == RatchetWrench.Repo.convert_value(now_timestamp)
+    assert params.updated_at == RatchetWrench.Repo.convert_value(now_timestamp)
   end
 
   test ".paramTypes/1" do


### PR DESCRIPTION
In my app have:

```elixir
singer = RatchetRench.Repo.insert(singer)
assert RatchetRench.Repo.get(Singer, [singer.id]) == singer
```

```elixir
     Assertion with == failed
     code:  assert RatchetRench.Repo.get(Singer, [singer.id]) == singer
     left:  %Singer{
              singer_id: "62066e43-c179-4609-8ef6-8419d6787ac0"
              first_name: "Lewis",
              last_name: "Carroll",
              inserted_at: ~U[2020-07-06 04:20:53.740134Z], # wrong timestamp
              updated_at: ~U[2020-07-06 04:20:53.740134Z], # wrong timestamp
            }
     right: %Singer{
              singer_id: "62066e43-c179-4609-8ef6-8419d6787ac0"
              first_name: "Lewis",
              last_name: "Carroll",
              inserted_at: ~U[2020-07-06 04:20:53.740112Z],
              updated_at: ~U[2020-07-06 04:20:53.740112Z],
            }
```

The problem is caused by set the timestamp in struct and params to generated in different function.