### PR TITLE
Fix timestamp precision is not always same

### DIFF
--- a/lib/ratchet_wrench/repo.ex
+++ b/lib/ratchet_wrench/repo.ex
@@ -350,12 +350,15 @@ defmodule RatchetWrench.Repo do
     {:ok, timestamp, _} = DateTime.from_iso8601(value)
     tz = System.get_env("TZ")
 
-    if tz == nil  do
-      timestamp
-    else
-      {:ok, datetime} = DateTime.shift_zone(timestamp, tz, Tzdata.TimeZoneDatabase)
-      datetime
-    end
+    datetime =
+      if tz == nil  do
+        timestamp
+      else
+        {:ok, datetime} = DateTime.shift_zone(timestamp, tz, Tzdata.TimeZoneDatabase)
+        datetime
+      end
+
+    %{datetime | microsecond: {datetime.microsecond |> elem(0), 6} }
   end
 
   defp to_struct(module) do

--- a/test/ratchet_wrench/repo_test.exs
+++ b/test/ratchet_wrench/repo_test.exs
@@ -157,6 +157,24 @@ defmodule RatchetWrench.RepoTest do
     assert Enum.count(all_data_list) == 100
   end
 
+  test "returns same timestamp" do
+    time_stamp = DateTime.shift_zone!(~U[2020-07-06 04:21:35.096500Z], System.get_env("TZ"), Tzdata.TimeZoneDatabase)
+
+    new_data = %Data{string: Faker.String.base64(1024),
+                     bool: List.first(Enum.take_random([true, false], 1)),
+                     int: List.first(Enum.take_random(0..9, 1)),
+                     float: 99.9,
+                     date: Faker.Date.date_of_birth(),
+                     time_stamp: time_stamp
+                    }
+
+    {:ok, data} = RatchetWrench.Repo.insert(new_data)
+
+    result = RatchetWrench.Repo.get(Data, [data.data_id])
+
+    assert result.time_stamp == data.time_stamp
+  end
+
   test "get all records and where from Singer" do
     where_sql = "singer_id = @singer_id"
     params = %{singer_id: "3"}


### PR DESCRIPTION
Timestamp was truncated when the last k-digits are zero from spanner.
This issue can cause timestamp assertion failure between selected and inserted data.

I solved this problem by always adjusting the default precition of Elixir's Datetime.

before:
```elixir
time_stamp = DateTime.shift_zone!(~U[2020-07-06 04:21:35.096500Z], System.get_env("TZ"), Tzdata.TimeZoneDatabase)

new_data = %Data{string: Faker.String.base64(1024),
                 bool: List.first(Enum.take_random([true, false], 1)),
                 int: List.first(Enum.take_random(0..9, 1)),
                 float: 99.9,
                 date: Faker.Date.date_of_birth(),
                 time_stamp: time_stamp
                }

{:ok, data} = RatchetWrench.Repo.insert(new_data)
data.time_stamp #=> #DateTime<2020-07-06 13:21:35.0965+09:00 JST Asia/Tokyo>
```

after:
```
data.time_stamp #=> #DateTime<2020-07-06 13:21:35.096500+09:00 JST Asia/Tokyo>
```